### PR TITLE
Added functionality to reposition CaptureZones

### DIFF
--- a/ScreenCapture.NET/DirectX/DX11ScreenCapture.cs
+++ b/ScreenCapture.NET/DirectX/DX11ScreenCapture.cs
@@ -203,14 +203,7 @@ namespace ScreenCapture.NET
         /// <inheritdoc />
         public CaptureZone RegisterCaptureZone(int x, int y, int width, int height, int downscaleLevel = 0)
         {
-            if (_device == null) throw new ApplicationException("ScreenCapture isn't initialized.");
-
-            if (x < 0) throw new ArgumentException("x < 0");
-            if (y < 0) throw new ArgumentException("y < 0");
-            if (width <= 0) throw new ArgumentException("with <= 0");
-            if (height <= 0) throw new ArgumentException("height <= 0");
-            if ((x + width) > Display.Width) throw new ArgumentException("x + width > Display width");
-            if ((y + height) > Display.Height) throw new ArgumentException("y + height > Display height");
+            CaptureZoneValidityCheck(x, y, width, height);
 
             int unscaledWidth = width;
             int unscaledHeight = height;
@@ -250,6 +243,33 @@ namespace ScreenCapture.NET
 
                 return false;
             }
+        }
+
+        /// <inheritdoc />
+        public void RepositionCaptureZone(CaptureZone captureZone, int x, int y)
+        {
+            CaptureZoneValidityCheck(x, y, captureZone.UnscaledWidth, captureZone.UnscaledHeight);
+
+            lock (_captureZones)
+            {
+                if (!_captureZones.ContainsKey(captureZone))
+                    throw new ArgumentException("Non registered CaptureZone", nameof(captureZone));
+            }
+
+            captureZone.X = x;
+            captureZone.Y = y;
+        }
+
+        private void CaptureZoneValidityCheck(int x, int y, int width, int height)
+        {
+            if (_device == null) throw new ApplicationException("ScreenCapture isn't initialized.");
+
+            if (x < 0) throw new ArgumentException("x < 0");
+            if (y < 0) throw new ArgumentException("y < 0");
+            if (width <= 0) throw new ArgumentException("with <= 0");
+            if (height <= 0) throw new ArgumentException("height <= 0");
+            if ((x + width) > Display.Width) throw new ArgumentException("x + width > Display width");
+            if ((y + height) > Display.Height) throw new ArgumentException("y + height > Display height");
         }
 
         private void InitializeCaptureZone(in CaptureZone captureZone)

--- a/ScreenCapture.NET/IScreenCapture.cs
+++ b/ScreenCapture.NET/IScreenCapture.cs
@@ -37,9 +37,18 @@ namespace ScreenCapture.NET
         /// <summary>
         /// Removes the given <see cref="CaptureScreen"/> from the <see cref="IScreenCapture"/>.
         /// </summary>
-        /// <param name="captureZone">The previosly registered <see cref="CaptureScreen"/>.</param>
+        /// <param name="captureZone">The previously registered <see cref="CaptureScreen"/>.</param>
         /// <returns><c>true</c> if the <see cref="CaptureScreen"/> was successfully removed; otherwise, <c>false</c>.</returns>
         bool UnregisterCaptureZone(CaptureZone captureZone);
+
+        /// <summary>
+        /// Updates the position of the given <see cref="CaptureScreen"/>.
+        /// </summary>
+        /// <param name="captureZone">The previously registered <see cref="CaptureScreen"/>.</param>
+        /// <param name="x">The new x-location of the region on the screen.</param>
+        /// <param name="y">The new y-location of the region on the screen</param>
+        /// <returns><c>true</c> if the <see cref="CaptureScreen"/> was successfully repositioned; otherwise, <c>false</c>.</returns>
+        void RepositionCaptureZone(CaptureZone captureZone, int x, int y);
 
         /// <summary>
         /// Restarts the <see cref="IScreenCapture"/>.

--- a/ScreenCapture.NET/Model/CaptureZone.cs
+++ b/ScreenCapture.NET/Model/CaptureZone.cs
@@ -19,12 +19,12 @@ namespace ScreenCapture.NET
         /// <summary>
         /// Gets the x-location of the region on the screen.
         /// </summary>
-        public int X { get; }
+        public int X { get; internal set; }
 
         /// <summary>
         /// Gets the y-location of the region on the screen.
         /// </summary>
-        public int Y { get; }
+        public int Y { get; internal set; }
 
         /// <summary>
         /// Gets the width of the region on the screen.


### PR DESCRIPTION
I was in need of a quick way to reposition the CaptureZone location, and the only option was unregistering and registering back the CaptureZone. but the process of registering has too much memory overhead due to the allocation of the byte buffer array, which made things quite prohibitive if done on a high frame by frame scenario.

I noticed that, the way you implemented things, made it so that changing the position would have no actual impact on any of the other resources used, as long as it followed the same rules used during registering, since the textures and buffer would still keep the same values. So I kept most modifications on the IScreenCapture interface, and required only minimal and safe changes to the CaptureZone class.

If you believe any modifications need to be made, such as changing signatures to stay compliant with the rest of the code, or bumping the nuget version on my side before merging, please feel free to request them. Also I already tested the additions and it worked normally, without the overhead issue, as expected.